### PR TITLE
Fix python3 script not having friendly name.

### DIFF
--- a/.github/workflows/wiki_update.yml
+++ b/.github/workflows/wiki_update.yml
@@ -13,11 +13,12 @@ jobs:
       group: wiki-generation
       cancel-in-progress: false
     steps:
-      - name: Checkout Repository and run Markdown Patch-List
+      - name: Checkout Repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: python3 scripts/gen-markdown-patchlist.py
+      - name: Generate Markdown Patch-List
+        run: python3 scripts/gen-markdown-patchlist.py
       - name: Upload generated file to wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:


### PR DESCRIPTION
Corrects the checkout script in wiki_update script and gives the python3 run command a friendly name, Swift's publish script seems to automate it.