### PR TITLE
Fix dynamic ModelManager leak

### DIFF
--- a/fabric/src/main/java/org/embeddedt/modernfix/fabric/mixin/perf/dynamic_resources/ModelManagerMixin.java
+++ b/fabric/src/main/java/org/embeddedt/modernfix/fabric/mixin/perf/dynamic_resources/ModelManagerMixin.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -43,8 +44,8 @@ public class ModelManagerMixin {
 
     private BlockModel loadSingleBlockModel(ResourceManager manager, ResourceLocation location) {
         return manager.getResource(location).map(resource -> {
-            try {
-                return BlockModel.fromStream(resource.openAsReader());
+            try (BufferedReader reader = resource.openAsReader()) {
+                return BlockModel.fromStream(reader);
             } catch(IOException e) {
                 ModernFix.LOGGER.error("Couldn't load model", e);
                 return null;
@@ -54,8 +55,8 @@ public class ModelManagerMixin {
 
     private List<ModelBakery.LoadedJson> loadSingleBlockState(ResourceManager manager, ResourceLocation location) {
         return manager.getResourceStack(location).stream().map(resource -> {
-            try {
-                return new ModelBakery.LoadedJson(resource.sourcePackId(), GsonHelper.parse(resource.openAsReader()));
+            try (BufferedReader reader = resource.openAsReader()) {
+                return new ModelBakery.LoadedJson(resource.sourcePackId(), GsonHelper.parse(reader));
             } catch(IOException e) {
                 ModernFix.LOGGER.error("Couldn't load blockstate", e);
                 return null;

--- a/forge/src/main/java/org/embeddedt/modernfix/forge/mixin/perf/dynamic_resources/ModelManagerMixin.java
+++ b/forge/src/main/java/org/embeddedt/modernfix/forge/mixin/perf/dynamic_resources/ModelManagerMixin.java
@@ -18,7 +18,9 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;

--- a/forge/src/main/java/org/embeddedt/modernfix/forge/mixin/perf/dynamic_resources/ModelManagerMixin.java
+++ b/forge/src/main/java/org/embeddedt/modernfix/forge/mixin/perf/dynamic_resources/ModelManagerMixin.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -41,8 +42,8 @@ public class ModelManagerMixin {
 
     private BlockModel loadSingleBlockModel(ResourceManager manager, ResourceLocation location) {
         return manager.getResource(location).map(resource -> {
-            try {
-                return BlockModel.fromStream(resource.openAsReader());
+            try (BufferedReader reader = resource.openAsReader()) {
+                return BlockModel.fromStream(reader);
             } catch(IOException e) {
                 ModernFix.LOGGER.error("Couldn't load model", e);
                 return null;
@@ -52,8 +53,8 @@ public class ModelManagerMixin {
 
     private List<ModelBakery.LoadedJson> loadSingleBlockState(ResourceManager manager, ResourceLocation location) {
         return manager.getResourceStack(location).stream().map(resource -> {
-            try {
-                return new ModelBakery.LoadedJson(resource.sourcePackId(), GsonHelper.parse(resource.openAsReader()));
+            try (BufferedReader reader = resource.openAsReader()) {
+                return new ModelBakery.LoadedJson(resource.sourcePackId(), GsonHelper.parse(reader));
             } catch(IOException e) {
                 ModernFix.LOGGER.error("Couldn't load blockstate", e);
                 return null;


### PR DESCRIPTION
When loading a single model/blockstate, a `Resource` has its `BufferedReader` reader opened but never closed. This leaks away resources/native memory such as `Inflater` (traceable via jemalloc). This is *possibly slow and insidious*, noticeable after several hours of gameplay.
This PR fixes it so it is auto closed and is confirmed to be working on 1.20 and will work on 1.19.4, due to the methods fixed being identical across the branches.