### PR TITLE
Fix silent sounds (1.16)

### DIFF
--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/dynamic_sounds/SoundBufferLibraryMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/dynamic_sounds/SoundBufferLibraryMixin.java
@@ -1,6 +1,7 @@
 package org.embeddedt.modernfix.common.mixin.perf.dynamic_sounds;
 
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
 import com.google.common.cache.RemovalNotification;
 import com.mojang.blaze3d.audio.SoundBuffer;
 import net.minecraft.client.sounds.SoundBufferLibrary;
@@ -26,6 +27,7 @@ public abstract class SoundBufferLibraryMixin {
     @Shadow @Final @Mutable
     private Map<ResourceLocation, CompletableFuture<SoundBuffer>> cache = CacheBuilder.newBuilder()
         .expireAfterAccess(DynamicSoundHelpers.MAX_SOUND_LIFETIME_SECS, TimeUnit.SECONDS)
+        .concurrencyLevel(1)
         // Excessive use of type hinting due to it assuming Object as the broadest correct type
         .<ResourceLocation, CompletableFuture<SoundBuffer>>removalListener(this::onSoundRemoval)
         .build()

--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/dynamic_sounds/SoundBufferLibraryMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/dynamic_sounds/SoundBufferLibraryMixin.java
@@ -32,6 +32,8 @@ public abstract class SoundBufferLibraryMixin {
         .asMap();
 
     private <K extends ResourceLocation, V extends CompletableFuture<SoundBuffer>> void onSoundRemoval(RemovalNotification<K, V> notification) {
+        if(notification.getCause() == RemovalCause.REPLACED && notification.getValue() == cache.get(notification.getKey()))
+            return;
         notification.getValue().thenAccept(SoundBuffer::discardAlBuffer);
         if(debugDynamicSoundLoading) {
             K k = notification.getKey();


### PR DESCRIPTION
1.16.5 uses a version of guava library afflicted by google/guava#3081
This re-implements guava PR to the removal listener, and sets concurrency level to 1 since the original Map isn't thread-safe.