### PR TITLE
Re-enable dynamic sounds

### DIFF
--- a/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
+++ b/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
@@ -161,7 +161,6 @@ public class ModernFixEarlyConfig {
 
     private static final ImmutableMap<String, Boolean> DEFAULT_SETTING_OVERRIDES = new DefaultSettingMapBuilder()
             .put("mixin.perf.dynamic_resources", false)
-            .put("mixin.perf.dynamic_sounds", false)
             .put("mixin.perf.reuse_datapacks", false)
             .put("mixin.perf.dynamic_block_codecs", false)
             .put("mixin.feature.direct_stack_trace", false)


### PR DESCRIPTION
Seeing as #259 was merged and that is due to Guava being broken for 1.16.x, I am proposing to enable dynamic sounds again.