### PR TITLE
Manually inline banner renderer call

### DIFF
--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/inline_methods/BannerRendererMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/inline_methods/BannerRendererMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.blockentity.BannerRenderer;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.core.Holder;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import org.embeddedt.modernfix.annotation.ClientOnlyMixin;
@@ -31,7 +30,7 @@ public abstract class BannerRendererMixin {
 			target = "Lnet/minecraft/client/renderer/blockentity/BannerRenderer;renderPatterns(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IILnet/minecraft/client/model/geom/ModelPart;Lnet/minecraft/client/resources/model/Material;ZLjava/util/List;)V"
 		)
 	)
-	private static void inlineRenderCanvas(PoseStack poseStack, MultiBufferSource multiBufferSource, int light, int overlay, ModelPart modelPart, Material material, boolean isBanner, List<Pair<Holder<BannerPattern>, DyeColor>> patterns) {
+	private static void inlineRenderCanvas(PoseStack poseStack, MultiBufferSource multiBufferSource, int light, int overlay, ModelPart modelPart, Material material, boolean isBanner, List<Pair<BannerPattern, DyeColor>> patterns) {
 		BannerRenderer.renderPatterns(poseStack, multiBufferSource, light, overlay, modelPart, material, isBanner, patterns, false);
 	}
 }

--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/inline_methods/BannerRendererMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/inline_methods/BannerRendererMixin.java
@@ -1,0 +1,37 @@
+package org.embeddedt.modernfix.common.mixin.perf.inline_methods;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.blockentity.BannerRenderer;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.entity.BannerPattern;
+import org.embeddedt.modernfix.annotation.ClientOnlyMixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.List;
+
+@Mixin(BannerRenderer.class)
+@ClientOnlyMixin
+public abstract class BannerRendererMixin {
+	
+	/**
+	 * @author Fury_Phoenix
+	 * @reason JIT doesn't inline due to too much stack
+	 */
+	@Redirect(
+		method = "render",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/client/renderer/blockentity/BannerRenderer;renderPatterns(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IILnet/minecraft/client/model/geom/ModelPart;Lnet/minecraft/client/resources/model/Material;ZLjava/util/List;)V"
+		)
+	)
+	private static void inlineRenderCanvas(PoseStack poseStack, MultiBufferSource multiBufferSource, int light, int overlay, ModelPart modelPart, Material material, boolean isBanner, List<Pair<Holder<BannerPattern>, DyeColor>> patterns) {
+		BannerRenderer.renderPatterns(poseStack, multiBufferSource, light, overlay, modelPart, material, isBanner, patterns, false);
+	}
+}


### PR DESCRIPTION
As of 1.18 (Actually 1.17), Mojang introduced an overload to `renderPatterns`. However this is not optimized by the JIT because its too stack heavy. This PR manually inlines it. In a profile of 8 minutes in a moderate usage of banners it takes up 0.03% of time with the overload call.