### PR TITLE
Remove testmod genSources task

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,8 @@ pluginManagement {
 include("test_agent")
 include("common")
 
+startParameter.excludedTaskNames.add(':fabric:testmod:genSources')
+
 def current_platforms = getProperty("enabled_platforms").tokenize(',')
 current_platforms.each { it ->
     def platform_name = it.trim()


### PR DESCRIPTION
No need to generate sources for the nested testmod project.