### PR TITLE
Remove Redundant Caching on Surface Rule Conditions

### DIFF
--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesContextMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesContextMixin.java
@@ -3,6 +3,7 @@ package org.embeddedt.modernfix.common.mixin.perf.worldgen_allocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.SurfaceRules;
 import org.embeddedt.modernfix.world.gen.PositionalBiomeGetter;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,23 +13,23 @@ import org.spongepowered.asm.mixin.Shadow;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-@Mixin(targets = {"net/minecraft/world/level/levelgen/SurfaceRules$Context"}, priority = 100)
+@Mixin(value = SurfaceRules.Context.class, priority = 100)
 public class SurfaceRulesContextMixin {
-    @Shadow private long lastUpdateY;
+    @Shadow long lastUpdateY;
 
-    @Shadow private int blockY;
+    @Shadow public int blockY;
 
-    @Shadow private int waterHeight;
+    @Shadow public int waterHeight;
 
-    @Shadow private int stoneDepthBelow;
+    @Shadow public int stoneDepthBelow;
 
-    @Shadow private int stoneDepthAbove;
+    @Shadow public int stoneDepthAbove;
 
-    @Shadow private Supplier<Holder<Biome>> biome;
+    @Shadow public Supplier<Holder<Biome>> biome;
 
     @Shadow @Final private Function<BlockPos, Holder<Biome>> biomeGetter;
 
-    @Shadow @Final private BlockPos.MutableBlockPos pos;
+    @Shadow @Final BlockPos.MutableBlockPos pos;
 
     /**
      * @author embeddedt

--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
@@ -20,12 +20,11 @@ import java.util.function.Predicate;
 public class SurfaceRulesMixin {
     @Mixin(value = SurfaceRules.BiomeConditionSource.class, priority = 100)
     public static final class BiomeConditionSource {
-        @Final
-        @Shadow
-        Predicate<ResourceKey<Biome>> biomeNameTest;
+        @Final @Shadow Predicate<ResourceKey<Biome>> biomeNameTest;
         /**
          * @author VoidsongDragonfly
-         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior.
+         * This is an exact reimplementation of the surface rule, without the caching; check code and effect are identical.
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
@@ -41,10 +40,16 @@ public class SurfaceRulesMixin {
     }
 
     @Mixin(value = SurfaceRules.StoneDepthCheck.class, priority = 100)
-    public record StoneDepthCheck(int offset, boolean addSurfaceDepth, int secondaryDepthRange, CaveSurface surfaceType) {
+    public static final class StoneDepthCheck {
+        @Final @Shadow int offset;
+        @Final @Shadow boolean addSurfaceDepth;
+        @Final @Shadow int secondaryDepthRange;
+        @Final @Shadow private CaveSurface surfaceType;
+
         /**
          * @author VoidsongDragonfly
-         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior.
+         * This is an exact reimplementation of the surface rule, without the caching; check code and effect are identical.
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
@@ -68,17 +73,22 @@ public class SurfaceRulesMixin {
     }
 
     @Mixin(value = SurfaceRules.VerticalGradientConditionSource.class, priority = 100)
-    public record VerticalGradientConditionSource(ResourceLocation randomName, VerticalAnchor trueAtAndBelow, VerticalAnchor falseAtAndAbove) {
+    public static final class VerticalGradientConditionSource {
+        @Final @Shadow private ResourceLocation randomName;
+        @Final @Shadow private VerticalAnchor trueAtAndBelow;
+        @Final @Shadow private VerticalAnchor falseAtAndAbove;
+
         /**
          * @author VoidsongDragonfly
-         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior.
+         * This is an exact reimplementation of the surface rule, without the caching; check code and effect are identical.
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
             // Copied Vanilla variables
-            final int i = this.trueAtAndBelow().resolveY(pContext.context);
-            final int j = this.falseAtAndAbove().resolveY(pContext.context);
-            final PositionalRandomFactory positionalrandomfactory = pContext.randomState.getOrCreateRandomFactory(this.randomName());
+            final int i = trueAtAndBelow.resolveY(pContext.context);
+            final int j = falseAtAndAbove.resolveY(pContext.context);
+            final PositionalRandomFactory positionalrandomfactory = pContext.randomState.getOrCreateRandomFactory(randomName);
 
             class VerticalGradientCondition implements SurfaceRules.Condition {
                 @Override
@@ -101,10 +111,15 @@ public class SurfaceRulesMixin {
     }
 
     @Mixin(value = SurfaceRules.WaterConditionSource.class, priority = 100)
-    public record WaterConditionSource(int offset, int surfaceDepthMultiplier, boolean addStoneDepth) {
+    public static final class WaterConditionSource {
+        @Final @Shadow int offset;
+        @Final @Shadow int surfaceDepthMultiplier;
+        @Final @Shadow boolean addStoneDepth;
+
         /**
          * @author VoidsongDragonfly
-         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior.
+         * This is an exact reimplementation of the surface rule, without the caching; check code and effect are identical.
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
@@ -125,10 +140,14 @@ public class SurfaceRulesMixin {
     }
 
     @Mixin(value = SurfaceRules.YConditionSource.class, priority = 100)
-    public record YConditionSource(VerticalAnchor anchor, int surfaceDepthMultiplier, boolean addStoneDepth) {
+    public static final class YConditionSource {
+        @Final @Shadow VerticalAnchor anchor;
+        @Final @Shadow int surfaceDepthMultiplier;
+        @Final @Shadow boolean addStoneDepth;
         /**
          * @author VoidsongDragonfly
-         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior.
+         * This is an exact reimplementation of the surface rule, without the caching; check code and effect are identical.
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {

--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
@@ -2,13 +2,12 @@ package org.embeddedt.modernfix.common.mixin.perf.worldgen_allocation;
 
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Mth;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.PositionalRandomFactory;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.placement.CaveSurface;
+import org.embeddedt.modernfix.world.gen.SurfaceConditionRecords;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -16,7 +15,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.function.Predicate;
 
-@Mixin(SurfaceRules.class)
+
 public class SurfaceRulesMixin {
     @Mixin(value = SurfaceRules.BiomeConditionSource.class, priority = 100)
     public static final class BiomeConditionSource {
@@ -28,14 +27,8 @@ public class SurfaceRulesMixin {
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
-            class BiomeCondition implements SurfaceRules.Condition {
-                @Override
-                public boolean test() {
-                    return pContext.biome.get().is(biomeNameTest);
-                }
-            }
-
-            return new BiomeCondition();
+            // Return the condition; this record is kept outside the class at embeddedt's wishes due to mixin compat concerns
+            return new SurfaceConditionRecords.PerformantBiomeCondition(pContext, biomeNameTest);
         }
     }
 
@@ -55,20 +48,8 @@ public class SurfaceRulesMixin {
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
             // Copied Vanilla variables
             final boolean flag = this.surfaceType == CaveSurface.CEILING;
-
-            class StoneDepthCondition implements SurfaceRules.Condition {
-                @Override
-                public boolean test() {
-                    int i = flag ? pContext.stoneDepthBelow : pContext.stoneDepthAbove;
-                    int j = addSurfaceDepth ? pContext.surfaceDepth : 0;
-                    int k = secondaryDepthRange == 0
-                        ? 0
-                        : (int) Mth.map(pContext.getSurfaceSecondary(), -1.0, 1.0, 0.0, secondaryDepthRange);
-                    return i <= 1 + offset + j + k;
-                }
-            }
-
-            return new StoneDepthCondition();
+            // Return the condition; this record is kept outside the class at embeddedt's wishes due to mixin compat concerns
+            return new SurfaceConditionRecords.PerformantStoneDepthCondition(pContext, offset, addSurfaceDepth, secondaryDepthRange, flag);
         }
     }
 
@@ -88,25 +69,9 @@ public class SurfaceRulesMixin {
             // Copied Vanilla variables
             final int i = trueAtAndBelow.resolveY(pContext.context);
             final int j = falseAtAndAbove.resolveY(pContext.context);
-            final PositionalRandomFactory positionalrandomfactory = pContext.randomState.getOrCreateRandomFactory(randomName);
-
-            class VerticalGradientCondition implements SurfaceRules.Condition {
-                @Override
-                public boolean test() {
-                    int k = pContext.blockY;
-                    if (k <= i) {
-                        return true;
-                    } else if (k >= j) {
-                        return false;
-                    } else {
-                        double d0 = Mth.map(k, i, j, 1.0, 0.0);
-                        RandomSource randomsource = positionalrandomfactory.at(pContext.blockX, k, pContext.blockZ);
-                        return (double)randomsource.nextFloat() < d0;
-                    }
-                }
-            }
-
-            return new VerticalGradientCondition();
+            final PositionalRandomFactory positionalRandomFactory = pContext.randomState.getOrCreateRandomFactory(randomName);
+            // Return the condition; this record is kept outside the class at embeddedt's wishes due to mixin compat concerns
+            return new SurfaceConditionRecords.PerformantVerticalGradientCondition(pContext, i, j, positionalRandomFactory);
         }
     }
 
@@ -123,18 +88,8 @@ public class SurfaceRulesMixin {
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
-            class WaterCondition implements SurfaceRules.Condition {
-                @Override
-                public boolean test() {
-                    return pContext.waterHeight == Integer.MIN_VALUE
-                        || pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
-                        >= pContext.waterHeight
-                        + offset
-                        + pContext.surfaceDepth * surfaceDepthMultiplier;
-                }
-            }
-
-            return new WaterCondition();
+            // Return the condition; this record is kept outside the class at embeddedt's wishes due to mixin compat concerns
+            return new SurfaceConditionRecords.PerformantWaterCondition(pContext, offset, surfaceDepthMultiplier, addStoneDepth);
         }
 
     }
@@ -151,16 +106,8 @@ public class SurfaceRulesMixin {
          */
         @Overwrite
         public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
-            class YCondition implements SurfaceRules.Condition {
-                @Override
-                public boolean test() {
-                    return pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
-                        >= anchor.resolveY(pContext.context)
-                        + pContext.surfaceDepth * surfaceDepthMultiplier;
-                }
-            }
-
-            return new YCondition();
+            // Return the condition; this record is kept outside the class at embeddedt's wishes due to mixin compat concerns
+            return new SurfaceConditionRecords.PerformantYCondition(pContext, anchor, surfaceDepthMultiplier, addStoneDepth);
         }
     }
 }

--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/perf/worldgen_allocation/SurfaceRulesMixin.java
@@ -1,0 +1,147 @@
+package org.embeddedt.modernfix.common.mixin.perf.worldgen_allocation;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.SurfaceRules;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.placement.CaveSurface;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.function.Predicate;
+
+@Mixin(SurfaceRules.class)
+public class SurfaceRulesMixin {
+    @Mixin(value = SurfaceRules.BiomeConditionSource.class, priority = 100)
+    public static final class BiomeConditionSource {
+        @Final
+        @Shadow
+        Predicate<ResourceKey<Biome>> biomeNameTest;
+        /**
+         * @author VoidsongDragonfly
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         */
+        @Overwrite
+        public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
+            class BiomeCondition implements SurfaceRules.Condition {
+                @Override
+                public boolean test() {
+                    return pContext.biome.get().is(biomeNameTest);
+                }
+            }
+
+            return new BiomeCondition();
+        }
+    }
+
+    @Mixin(value = SurfaceRules.StoneDepthCheck.class, priority = 100)
+    public record StoneDepthCheck(int offset, boolean addSurfaceDepth, int secondaryDepthRange, CaveSurface surfaceType) {
+        /**
+         * @author VoidsongDragonfly
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         */
+        @Overwrite
+        public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
+            // Copied Vanilla variables
+            final boolean flag = this.surfaceType == CaveSurface.CEILING;
+
+            class StoneDepthCondition implements SurfaceRules.Condition {
+                @Override
+                public boolean test() {
+                    int i = flag ? pContext.stoneDepthBelow : pContext.stoneDepthAbove;
+                    int j = addSurfaceDepth ? pContext.surfaceDepth : 0;
+                    int k = secondaryDepthRange == 0
+                        ? 0
+                        : (int) Mth.map(pContext.getSurfaceSecondary(), -1.0, 1.0, 0.0, secondaryDepthRange);
+                    return i <= 1 + offset + j + k;
+                }
+            }
+
+            return new StoneDepthCondition();
+        }
+    }
+
+    @Mixin(value = SurfaceRules.VerticalGradientConditionSource.class, priority = 100)
+    public record VerticalGradientConditionSource(ResourceLocation randomName, VerticalAnchor trueAtAndBelow, VerticalAnchor falseAtAndAbove) {
+        /**
+         * @author VoidsongDragonfly
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         */
+        @Overwrite
+        public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
+            // Copied Vanilla variables
+            final int i = this.trueAtAndBelow().resolveY(pContext.context);
+            final int j = this.falseAtAndAbove().resolveY(pContext.context);
+            final PositionalRandomFactory positionalrandomfactory = pContext.randomState.getOrCreateRandomFactory(this.randomName());
+
+            class VerticalGradientCondition implements SurfaceRules.Condition {
+                @Override
+                public boolean test() {
+                    int k = pContext.blockY;
+                    if (k <= i) {
+                        return true;
+                    } else if (k >= j) {
+                        return false;
+                    } else {
+                        double d0 = Mth.map(k, i, j, 1.0, 0.0);
+                        RandomSource randomsource = positionalrandomfactory.at(pContext.blockX, k, pContext.blockZ);
+                        return (double)randomsource.nextFloat() < d0;
+                    }
+                }
+            }
+
+            return new VerticalGradientCondition();
+        }
+    }
+
+    @Mixin(value = SurfaceRules.WaterConditionSource.class, priority = 100)
+    public record WaterConditionSource(int offset, int surfaceDepthMultiplier, boolean addStoneDepth) {
+        /**
+         * @author VoidsongDragonfly
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         */
+        @Overwrite
+        public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
+            class WaterCondition implements SurfaceRules.Condition {
+                @Override
+                public boolean test() {
+                    return pContext.waterHeight == Integer.MIN_VALUE
+                        || pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
+                        >= pContext.waterHeight
+                        + offset
+                        + pContext.surfaceDepth * surfaceDepthMultiplier;
+                }
+            }
+
+            return new WaterCondition();
+        }
+
+    }
+
+    @Mixin(value = SurfaceRules.YConditionSource.class, priority = 100)
+    public record YConditionSource(VerticalAnchor anchor, int surfaceDepthMultiplier, boolean addStoneDepth) {
+        /**
+         * @author VoidsongDragonfly
+         * @reason Replacing Vanilla's use of {@link SurfaceRules.LazyYCondition LazyYCondition} that causes performance detriments due to unused caching behavior
+         */
+        @Overwrite
+        public SurfaceRules.Condition apply(final SurfaceRules.Context pContext) {
+            class YCondition implements SurfaceRules.Condition {
+                @Override
+                public boolean test() {
+                    return pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
+                        >= anchor.resolveY(pContext.context)
+                        + pContext.surfaceDepth * surfaceDepthMultiplier;
+                }
+            }
+
+            return new YCondition();
+        }
+    }
+}

--- a/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
+++ b/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
@@ -165,7 +165,7 @@ public class ModernFixEarlyConfig {
             .put("mixin.feature.stalled_chunk_load_detection", false)
             .put("mixin.perf.blast_search_trees.force", false)
             .put("mixin.bugfix.restore_old_dragon_movement", false)
-            .put("mixin.perf.worldgen_allocation", false) // experimental
+            .put("mixin.perf.worldgen_allocation", true)
             .put("mixin.feature.cause_lag_by_disabling_threads", false)
             .put("mixin.bugfix.missing_block_entities", false)
             .put("mixin.feature.blockentity_incorrect_thread", false)

--- a/common/src/main/java/org/embeddedt/modernfix/world/gen/SurfaceConditionRecords.java
+++ b/common/src/main/java/org/embeddedt/modernfix/world/gen/SurfaceConditionRecords.java
@@ -1,0 +1,68 @@
+package org.embeddedt.modernfix.world.gen;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.SurfaceRules;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+
+import java.util.function.Predicate;
+
+public class SurfaceConditionRecords {
+    public record PerformantBiomeCondition(SurfaceRules.Context pContext, Predicate<ResourceKey<Biome>> biomeNameTest) implements SurfaceRules.Condition {
+        @Override
+        public boolean test() {
+            return pContext.biome.get().is(biomeNameTest);
+        }
+    }
+
+    public record PerformantStoneDepthCondition(SurfaceRules.Context pContext, int offset, boolean addSurfaceDepth, int secondaryDepthRange, boolean flag) implements SurfaceRules.Condition {
+        @Override
+        public boolean test() {
+            int i = flag ? pContext.stoneDepthBelow : pContext.stoneDepthAbove;
+            int j = addSurfaceDepth ? pContext.surfaceDepth : 0;
+            int k = secondaryDepthRange == 0
+                ? 0
+                : (int) Mth.map(pContext.getSurfaceSecondary(), -1.0, 1.0, 0.0, secondaryDepthRange);
+            return i <= 1 + offset + j + k;
+        }
+    }
+
+    public record PerformantVerticalGradientCondition(SurfaceRules.Context pContext, int i, int j, PositionalRandomFactory positionalRandomFactory) implements SurfaceRules.Condition {
+        @Override
+        public boolean test() {
+            int k = pContext.blockY;
+            if (k <= i) {
+                return true;
+            } else if (k >= j) {
+                return false;
+            } else {
+                double d0 = Mth.map(k, i, j, 1.0, 0.0);
+                RandomSource randomsource = positionalRandomFactory.at(pContext.blockX, k, pContext.blockZ);
+                return (double)randomsource.nextFloat() < d0;
+            }
+        }
+    }
+
+    public record PerformantWaterCondition(SurfaceRules.Context pContext, int offset, int surfaceDepthMultiplier, boolean addStoneDepth) implements SurfaceRules.Condition {
+        @Override
+        public boolean test() {
+            return pContext.waterHeight == Integer.MIN_VALUE
+                || pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
+                >= pContext.waterHeight
+                + offset
+                + pContext.surfaceDepth * surfaceDepthMultiplier;
+        }
+    }
+
+    public record PerformantYCondition(SurfaceRules.Context pContext, VerticalAnchor anchor, int surfaceDepthMultiplier, boolean addStoneDepth) implements SurfaceRules.Condition {
+        @Override
+        public boolean test() {
+            return pContext.blockY + (addStoneDepth ? pContext.stoneDepthAbove : 0)
+                >= anchor.resolveY(pContext.context)
+                + pContext.surfaceDepth * surfaceDepthMultiplier;
+        }
+    }
+}

--- a/common/src/main/resources/modernfix.accesswidener
+++ b/common/src/main/resources/modernfix.accesswidener
@@ -23,7 +23,7 @@ accessible class net/minecraft/world/level/levelgen/SurfaceRules$SequenceRule
 accessible class net/minecraft/world/level/levelgen/SurfaceRules$SurfaceRule
 # Access to allow working with Context
 accessible class net/minecraft/world/level/levelgen/SurfaceRules$Context
-accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context context Lnet/minecraft/world/level/levelgen/SurfaceRules$Context;
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context context Lnet/minecraft/world/level/levelgen/WorldGenerationContext;
 accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context biome Ljava/util/function/Supplier;
 accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context blockX I
 accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context blockY I

--- a/common/src/main/resources/modernfix.accesswidener
+++ b/common/src/main/resources/modernfix.accesswidener
@@ -11,8 +11,30 @@ accessible field net/minecraft/world/level/Level blockEntityTickers Ljava/util/L
 accessible class net/minecraft/client/renderer/RenderType$CompositeRenderType
 accessible method net/minecraft/nbt/CompoundTag <init> (Ljava/util/Map;)V
 
+# Non-context access necessary
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$Condition
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$LazyYCondition
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$StoneDepthCheck
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$WaterConditionSource
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$VerticalGradientConditionSource
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$YConditionSource
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$BiomeConditionSource
 accessible class net/minecraft/world/level/levelgen/SurfaceRules$SequenceRule
 accessible class net/minecraft/world/level/levelgen/SurfaceRules$SurfaceRule
+# Access to allow working with Context
+accessible class net/minecraft/world/level/levelgen/SurfaceRules$Context
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context context Lnet/minecraft/world/level/levelgen/SurfaceRules$Context;
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context biome Ljava/util/function/Supplier;
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context blockX I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context blockY I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context blockZ I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context stoneDepthBelow I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context randomState Lnet/minecraft/world/level/levelgen/RandomState;
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context waterHeight I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context stoneDepthAbove I
+accessible field net/minecraft/world/level/levelgen/SurfaceRules$Context surfaceDepth I
+accessible method net/minecraft/world/level/levelgen/SurfaceRules$Context getSurfaceSecondary ()D
+# Density function access
 accessible class net/minecraft/world/level/levelgen/DensityFunctions$Marker
 accessible class net/minecraft/world/level/levelgen/DensityFunctions$Marker$Type
 accessible method net/minecraft/world/level/levelgen/DensityFunctions$Marker <init> (Lnet/minecraft/world/level/levelgen/DensityFunctions$Marker$Type;Lnet/minecraft/world/level/levelgen/DensityFunction;)V


### PR DESCRIPTION
### Summary
This PR deals with some issues with Vanilla and (more) ineffective caching on the worldgen side, within surface rules.

### The Issue With Vanilla Behavior

Because of how Vanilla codecs create an object per non-interned JSON object, interactions `LazyYCondition` (which should be `LazyXYZCondition`, because it's per-position), cause the caching implemented on `LazyYCondition` to be actively detrimental, as the cache is unused most of the time.

For the cache to be used, it must be either interned (not currently done) or an equivalent must happen, such as with `TemperatureHelperCondition`, where a single instance is stored in the `SurfaceRules#Context` and accessed from there by the `ConditionSource`. Without that, the `LazyYCondition`-inherting condition is evaluated once, before the cache is never accessed again due to the change in the position; which means all of the caching behavior is and time and memory spent on creating a cache that is then destroyed when the next position is moved to.

Parameterized conditions are never stored; this includes most of the commonly used position-specific conditions, including `WaterCondition` and `StoneDepthCondition`, alongside the rare but highly-applied `VerticalGradientCondition`.

### Why This PR Doesn't Intern The Values

I believe the value of interning conditions would depend upon *which* conditions. Most* of the time in Vanilla or Vanilla-adjacent worldgen, there's not a lot of *highly duplicate equivalent conditions.* For some (water depth, stone depth) there are relatively few max total checks per object, and throughout the entirety of the Vanilla rule set, and you're not going to be hitting all of them at once (nor do all have the same parameters)

Even in old versions of my worldgen mod (Natural Philosophy), which use the Lithostitched surface rule injection system and thus duplicate many checks due to the split nature of their files, I don't think there's more than about sixty equivalent checks of any given type in total throughout the entirety of files, and any given block would at *absolute max* encounter no more than roughly forty of the same check at once - and not all of those would intern to the same values. That's if *every file* is checked against a single block before it happens to hit the right file.

Even this relatively large number of conditions is slated to be changed due to outsized performance impact, and I have a relatively easy method of doing so, which will in sum total produce better performance than implementing the interning and intended caching behavior of the conditions.

For things like `VerticalGradientConditionSource`, I believe there is even less reason to intern the condition and allow caching. The only time that condition exists in Vanilla is bedrock and deepslate. Interning those would *not* make them one object - two different heights and different blocks means different variables - and so you'd be caching the result for something simply not applied anywhere else, while the checks are run on basically every block.

### Possible Routes to Interning Values With Caching

To determine which conditions would be better left interned, I would want to run a deeper comparative performance analysis on a simulated surface system that can accurately mimic Vanilla generation without having randomness, with both "Vanilla case", and "Worst likely worldgen mod case" tests to figure out which is actually comparatively faster for most users. The specific methods that Terrablender does their surface rule addition with would *also* I think be of interest to analyze, as I haven't looked into their code, and I don't know if *they* have repeat checks with how mods commonly add rules with that.

### Performance Benefits

From testing with the code in a standalone mod as well as within ModernFix, I expect a roughly 10% boost to the speed of surface rule generation for a complex (windswept) Vanilla terrain; this will not map directly to worldgen performance boosts, I expect it to produce a roughly 5% bonus to worldgen performance due to it being sequentially done on-worldgen-thread with biome decor and structures.

Statistics are included below; please do ask if you want to know more about my methodology.
<img width="1066" height="601" alt="image" src="https://github.com/user-attachments/assets/cd2a0680-2462-447a-94a1-87f97ec8569e" />

### Mixin Category Enables

This PR enables the `Worldgen Performance` mixin category; it also has been tested to ensure compatibility.

The following mods have been tested and do not seem to cause issues:
 - Hydrological
 - Biomes o' Plenty
 - Oh The Biomes We've Gone
 - Moderner Beta
 - Terralith
 - Regions Unexplored
 - Nature's Spirit
