### PR TITLE
[1.20.1] Add mixin.feature.suppress_narrator_stacktrace

### DIFF
--- a/common/src/main/java/org/embeddedt/modernfix/common/mixin/feature/suppress_narrator_stacktrace/GameNarratorMixin.java
+++ b/common/src/main/java/org/embeddedt/modernfix/common/mixin/feature/suppress_narrator_stacktrace/GameNarratorMixin.java
@@ -1,0 +1,28 @@
+package org.embeddedt.modernfix.common.mixin.feature.suppress_narrator_stacktrace;
+
+import com.mojang.text2speech.Narrator;
+import com.mojang.text2speech.NarratorLinux;
+import com.mojang.text2speech.OperatingSystem;
+import net.minecraft.client.GameNarrator;
+import org.embeddedt.modernfix.ModernFix;
+import org.embeddedt.modernfix.annotation.ClientOnlyMixin;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@ClientOnlyMixin
+@Mixin(GameNarrator.class)
+public class GameNarratorMixin {
+    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/text2speech/Narrator;getNarrator()Lcom/mojang/text2speech/Narrator;"))
+    private Narrator suppressStacktracePrinting() {
+        try {
+            return switch (OperatingSystem.get()) {
+                case LINUX -> new NarratorLinux();
+                default -> Narrator.getNarrator();
+            };
+        } catch (Narrator.InitializeException e) {
+            ModernFix.LOGGER.warn("Failed to initialize Linux Narrator. Make sure you have libflite installed!");
+            return Narrator.EMPTY;
+        }
+    }
+}

--- a/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
+++ b/common/src/main/java/org/embeddedt/modernfix/core/config/ModernFixEarlyConfig.java
@@ -186,6 +186,7 @@ public class ModernFixEarlyConfig {
             .put("mixin.feature.log_stdout_in_log_files", true)
             .put("mixin.devenv", isDevEnv)
             .put("mixin.perf.remove_spawn_chunks", isDevEnv)
+            .put("mixin.feature.suppress_narrator_stacktrace", !isDevEnv) // Not compatible with mixin.devenv
             .putConditionally(() -> !isFabric, "mixin.bugfix.fix_config_crashes", true)
             .putConditionally(() -> !isFabric, "mixin.bugfix.forge_at_inject_error", true)
             .putConditionally(() -> !isFabric, "mixin.feature.registry_event_progress", false)

--- a/common/src/main/resources/assets/modernfix/lang/de_de.json
+++ b/common/src/main/resources/assets/modernfix/lang/de_de.json
@@ -120,5 +120,6 @@
   "modernfix.option.mixin.perf.compact_mojang_registries": "(Fabric) Experimentelle Option, die die Speichernutzung von Registern um etwa 50 % reduziert. In den meisten Modpacks nicht nützlich, es sei denn, sie enthalten Millionen von Blöcken und Gegenständen.",
   "modernfix.option.mixin.perf.dynamic_block_codecs": "Vermeidet das Speichern eines Codecs für jeden Block (Zustand) und generiert und speichert ihn stattdessen bei Bedarf im laufenden Betrieb. Im Allgemeinen lohnt es sich nicht, es zu aktivieren, es sei denn, Sie haben eine Million Blöcke/Elemente.",
   "modernfix.option.mixin.perf.faster_command_suggestions": "Verringern Sie Verzögerungen, wenn beim Eingeben eines Befehls Hunderttausende Vorschläge eingehen",
-  "modernfix.option.mixin.perf.mojang_registry_size": "Behebt ein Problem, das dazu führt, dass sich die Registrierung von Blöcken/Elementen proportional zur bereits registrierten Anzahl verlangsamt. Dies verbessert die Startzeit."
+  "modernfix.option.mixin.perf.mojang_registry_size": "Behebt ein Problem, das dazu führt, dass sich die Registrierung von Blöcken/Elementen proportional zur bereits registrierten Anzahl verlangsamt. Dies verbessert die Startzeit.",
+  "modernfix.option.mixin.feature.suppress_narrator_stacktrace": "Hält das Spiel davon ab, einen sehr langen Stacktrace zu loggen, wenn der Erzähler auf Linux nicht erfolgreich lädt (oft verursacht dadurch, dass libflite nicht installiert ist)."
 }

--- a/common/src/main/resources/assets/modernfix/lang/en_us.json
+++ b/common/src/main/resources/assets/modernfix/lang/en_us.json
@@ -152,5 +152,6 @@
   "modernfix.option.mixin.perf.memoize_creative_tab_build": "Improves on vanilla's existing caching for creative tab contents in a way that is compatible with the timing requirements of mods like JEI/EMI. This can reduce the lag spike when opening the creative inventory for the first time in a modpack.",
   "modernfix.option.mixin.perf.potential_spawns_alloc": "Optimizes the Forge event for finding potential mobs that can spawn. This reduces allocations and the overhead of rebuilding a weighted list when no mods modify the potential spawns.",
   "modernfix.option.mixin.perf.ticking_chunk_alloc": "Optimizes chunk ticking in vanilla to reduce allocations.",
-  "modernfix.option.mixin.perf.worldgen_allocation": "Optimizes some world generation logic in vanilla to reduce object allocations."
+  "modernfix.option.mixin.perf.worldgen_allocation": "Optimizes some world generation logic in vanilla to reduce object allocations.",
+  "modernfix.option.mixin.feature.suppress_narrator_stacktrace": "Prevents the game from logging a very long stacktrace when the narrator fails to load on Linux (usually caused by not having libflite installed)."
 }


### PR DESCRIPTION
To prevent log spam on Linux systems that don't have libflite installed