### PR TITLE
Change debug thread dump log level from error to info

### DIFF
--- a/src/main/java/org/embeddedt/modernfix/core/ModernFixMixinPlugin.java
+++ b/src/main/java/org/embeddedt/modernfix/core/ModernFixMixinPlugin.java
@@ -78,8 +78,8 @@ public class ModernFixMixinPlugin implements IMixinConfigPlugin {
                         while(true) {
                             try {
                                 Thread.sleep(60000);
-                                logger.error("------ DEBUG THREAD DUMP (occurs every 60 seconds) ------");
-                                logger.error(ThreadDumper.obtainThreadDump());
+                                logger.info("------ DEBUG THREAD DUMP (occurs every 60 seconds) ------");
+                                logger.info(ThreadDumper.obtainThreadDump());
                             } catch(InterruptedException | RuntimeException e) {}
                         }
                     }


### PR DESCRIPTION
Prevents silly people assuming its an error condition. They shouldn't be enabling the debug options in the first place, and they will probably still think its an error because of the scary (for end-users) stack trace they can't understand, but i think making it info log level will be more sensible at least.

I've not made it debug log level but info instead intentionally, since debug log level would cause it to be invisible for most people instead.

An argument against this change would be that info instead of error would make it go to stdout instead of stderr or make it harder to see through other log lines; shouldn't be an issue since both are outputted to latest.log but i can change it to warn log level if desired, but feel free to close this PR if this not something you care enough about or want to keep it as error log level.

Relevant: https://github.com/decce6/Ixeris/issues/100