### PR TITLE
Change log level from warn to debug for successfully created missing …

### DIFF
--- a/src/main/java/org/embeddedt/modernfix/common/mixin/bugfix/missing_block_entities/LevelChunkMixin.java
+++ b/src/main/java/org/embeddedt/modernfix/common/mixin/bugfix/missing_block_entities/LevelChunkMixin.java
@@ -87,7 +87,9 @@ public abstract class LevelChunkMixin extends ChunkAccess {
         BlockEntity blockEntity = this.getBlockEntity(pos.immutable(), LevelChunk.EntityCreationType.IMMEDIATE);
         String blockName = state.getBlock().toString();
         if (blockEntity != null) {
-            ModernFix.LOGGER.debug("Created missing block entity for {} at {}", blockName, pos.toShortString());
+            if (ModernFix.LOGGER.isDebugEnabled()) {
+                ModernFix.LOGGER.debug("Created missing block entity for {} at {}", blockName, pos.toShortString());
+            }
         } else {
             ModernFix.LOGGER.error("Block entity is missing for {} at {}, but could not be created", blockName, pos.toShortString());
         }

--- a/src/main/java/org/embeddedt/modernfix/common/mixin/bugfix/missing_block_entities/LevelChunkMixin.java
+++ b/src/main/java/org/embeddedt/modernfix/common/mixin/bugfix/missing_block_entities/LevelChunkMixin.java
@@ -87,7 +87,7 @@ public abstract class LevelChunkMixin extends ChunkAccess {
         BlockEntity blockEntity = this.getBlockEntity(pos.immutable(), LevelChunk.EntityCreationType.IMMEDIATE);
         String blockName = state.getBlock().toString();
         if (blockEntity != null) {
-            ModernFix.LOGGER.warn("Created missing block entity for {} at {}", blockName, pos.toShortString());
+            ModernFix.LOGGER.debug("Created missing block entity for {} at {}", blockName, pos.toShortString());
         } else {
             ModernFix.LOGGER.error("Block entity is missing for {} at {}, but could not be created", blockName, pos.toShortString());
         }


### PR DESCRIPTION
…block entities

This message spams the logs in Hypixel. The else case already logs at error level; so logging it for the successful case would only bury the error case in the logs. I feel like debug log level would be apporiate here, which won't be logged by default at least on Fabric. I'm not sure if Forge still enables debug log level by default, please let me know.