### PR TITLE
 fix category lookup, loot table classification, structure radius math, and AP NPE

### DIFF
--- a/annotation-processor/src/main/java/org/fury_phoenix/mixinAp/annotation/MixinProcessor.java
+++ b/annotation-processor/src/main/java/org/fury_phoenix/mixinAp/annotation/MixinProcessor.java
@@ -89,8 +89,9 @@ public class MixinProcessor extends AbstractProcessor {
 
     private void filterMixinSets() {
         List<String> commonSet = mixinConfigList.get("mixins");
-        if(commonSet == null) return;
-        commonSet.removeAll(mixinConfigList.get("client"));
+        List<String> clientSet = mixinConfigList.get("client");
+        if(commonSet == null || clientSet == null) return;
+        commonSet.removeAll(clientSet);
     }
 
     private void validateCommonMixins(TypeElement annotation, Stream<TypeElement> mixins) {

--- a/src/main/java/org/embeddedt/modernfix/common/mixin/perf/cache_strongholds/ConcentricRingsStructurePlacementMixin.java
+++ b/src/main/java/org/embeddedt/modernfix/common/mixin/perf/cache_strongholds/ConcentricRingsStructurePlacementMixin.java
@@ -67,8 +67,8 @@ public class ConcentricRingsStructurePlacementMixin {
 
         // min(dist): 4*i + i*0*6 - maxNoise
         double minDist = 4.0 * this.distance - maxNoise;
-        double safeInnerRadius = minDist - MFIX_MAX_POSITION_ERROR;
-        this.mfix$innerRadiusSq = (long)Math.max(0.0, Math.floor(safeInnerRadius * safeInnerRadius));
+        double safeInnerRadius = Math.max(0.0, minDist - MFIX_MAX_POSITION_ERROR);
+        this.mfix$innerRadiusSq = (long)Math.floor(safeInnerRadius * safeInnerRadius);
 
         if (this.spread == 0) {
             // Vanilla behavior becomes non-finite here (angle += 2π / 0), so keep only inner rejection.

--- a/src/main/java/org/embeddedt/modernfix/common/mixin/perf/faster_loot_loading/LootDataManagerMixin.java
+++ b/src/main/java/org/embeddedt/modernfix/common/mixin/perf/faster_loot_loading/LootDataManagerMixin.java
@@ -32,7 +32,7 @@ public class LootDataManagerMixin {
         for (var entry : lootTableResourceMap.entrySet()) {
             if (lootTables.get(converter.fileToId(entry.getKey())) instanceof JsonObject obj) {
                 var resource = entry.getValue();
-                if (resource != null && !resource.isBuiltin()) {
+                if (resource != null && resource.isBuiltin()) {
                     obj.addProperty("mfix$isVanillaTable", true);
                 }
             }

--- a/src/main/java/org/embeddedt/modernfix/core/config/OptionCategories.java
+++ b/src/main/java/org/embeddedt/modernfix/core/config/OptionCategories.java
@@ -46,7 +46,7 @@ public class OptionCategories {
         if(category == null) {
             int lastDotIdx = optionName.lastIndexOf('.');
             if(lastDotIdx > 0) {
-                category = getCategoryForOption(optionName.substring(0, lastDotIdx - 1));
+                category = getCategoryForOption(optionName.substring(0, lastDotIdx));
             } else
                 category = defaultCategory;
         }


### PR DESCRIPTION
- **Fix off-by-one substring truncation in `OptionCategories`:**
  `getCategoryForOption()` used `optionName.substring(0, lastDotIdx - 1)` when recursively traversing parent option paths. Because `String.substring()` has an exclusive upper bound, this truncated the last character of parent option names (e.g., turning `"mixin.perf.dynamic_resources"` into `"mixin.perf.dynamic_resource"`). Consequently, sub-options failed to match their parent category and incorrectly fell back to the default `expert_only` category.

- **Fix inverted vanilla loot table check in `LootDataManagerMixin`:**
  The mixin checked `!resource.isBuiltin()` when tagging loot tables with `mfix$isVanillaTable`. Since vanilla tables return `true` for `isBuiltin()`, this tagged custom/modded loot tables as vanilla and left actual vanilla tables untagged. In `ForgeHooksMixin`, `custom = !mfix$isVanillaTable(data)` was computed, which completely inverted the custom vs. vanilla classification across Forge's loot loading pipeline.

- **Fix negative radius squaring in `ConcentricRingsStructurePlacementMixin`:**
  When computing inner radial bounds for concentric structure placements, `safeInnerRadius` (`minDist - MFIX_MAX_POSITION_ERROR`) can be negative for placements with small distances or configurations generating near the world origin. Squaring a negative number yielded a positive `mfix$innerRadiusSq`, causing `isPlacementChunk()` to falsely reject valid placement chunks near `(0, 0)`. Clamping `safeInnerRadius` to at least `0.0` before squaring prevents this false rejection.

- **Guard against `NullPointerException` in `MixinProcessor`:**
  `filterMixinSets()` called `commonSet.removeAll(mixinConfigList.get("client"))` without checking if the client mixin list was present. If a module contains no `@ClientOnlyMixin` annotations in a compilation round, `get("client")` returns `null`, which causes `Collection.removeAll(null)` to throw an NPE and fail the build.